### PR TITLE
fix: replace semantic-release with tag-based release (branch protection)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,45 +2,24 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
-  issues: write
-  pull-requests: write
 
 jobs:
   release:
-    name: Semantic Release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install python-semantic-release
-
-      - name: Python Semantic Release
-        id: release
-        uses: python-semantic-release/python-semantic-release@v9.15.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        if: steps.release.outputs.released == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.release.outputs.tag }}
-          body: ${{ steps.release.outputs.notes }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Problem

Semantic Release tried to push version bumps directly to \main\, which is protected and requires PRs + status checks. This caused:

`
GH006: Protected branch update failed for refs/heads/main
Changes must be made through a pull request
`

## Fix

Replaced semantic-release with a simple tag-based workflow:

- **Trigger**: Push a tag matching \*\ (e.g. \git tag v1.0.0 && git push origin v1.0.0\)
- **Action**: Creates a GitHub Release with auto-generated release notes

## How to create a release

\\\ash
git tag v1.0.0
git push origin v1.0.0
\\\

The GitHub Release will be created automatically with changelog from merged PRs.