### PR TITLE
fix: add missing gh pr create step to changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -171,5 +171,8 @@ jobs:
           fi
           git commit -m "docs: update CHANGELOG.md with PR #${{ steps.change_type.outputs.pr_number }}"
           git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "docs: update CHANGELOG.md (PR #${{ steps.change_type.outputs.pr_number }})" \
+            --body "Automated changelog update for PR #${{ steps.change_type.outputs.pr_number }}."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the missing \gh pr create\ command to the changelog workflow. Previously it pushed the branch but never created the PR.