### PR TITLE
fix: skip changelog PRs to prevent infinite loop

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   update-changelog:
     name: Update CHANGELOG.md
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'changelog/update-pr-')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Adds condition to skip changelog PRs so the workflow doesn't trigger itself endlessly.