### PR TITLE
ci: add auto-labeler workflow for PR size, type, and area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+# Area labels (applied based on changed files)
+area/CI:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+      - 'Dockerfile'
+      - '.pre-commit-config.yaml'
+
+area/documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CONTRIBUTING.md'
+
+area/code:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/**'
+
+area/scripts:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'scripts/**'
+
+area/experiments:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'experiments/**'
+
+area/configs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'configs/**'
+
+area/notebooks:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.ipynb'
+
+area/dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'requirements.txt'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'pyproject.toml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,67 @@
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-size:
+    name: Label PR Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by size
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: 10
+          s_max_size: 50
+          m_max_size: 200
+          l_max_size: 500
+          fail_if_xl: false
+
+  label-type:
+    name: Label PR Type
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by type (title prefix)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+            const labels = [];
+
+            if (title.startsWith('feat'))        labels.push('type/feature');
+            else if (title.startsWith('fix'))     labels.push('type/bugfix');
+            else if (title.startsWith('docs'))    labels.push('type/documentation');
+            else if (title.startsWith('chore'))   labels.push('type/chore');
+            else if (title.startsWith('refactor')) labels.push('type/refactor');
+            else if (title.startsWith('test'))    labels.push('type/test');
+            else if (title.startsWith('perf'))    labels.push('type/performance');
+            else if (title.startsWith('ci'))      labels.push('type/ci');
+            else if (title.startsWith('style'))   labels.push('type/style');
+
+            if (title.includes('wip') || title.includes('draft')) labels.push('status/WIP');
+            if (title.includes('breaking') || title.includes('breaking change')) labels.push('breaking');
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }
+
+  label-area:
+    name: Label PR Area
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by file path
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
Adds GitHub Actions workflow that automatically labels PRs based on:

- **Size**: XS/S/M/L/XL (based on lines changed)
- **Type**: feature, bugfix, docs, chore, refactor, test, performance, ci, style (based on PR title prefix)
- **Area**: CI, documentation, code, scripts, experiments, configs, notebooks, dependencies (based on file paths)
- **Status**: WIP (if title contains 'wip' or 'draft')
- **Breaking**: breaking change indicator

Creates 24 labels and configures path-based labeling via .github/labeler.yml.